### PR TITLE
feat: add automated daily AI health suggestions with backend storage

### DIFF
--- a/backend/alembic/versions/0041_health_ai_suggestion_runs.py
+++ b/backend/alembic/versions/0041_health_ai_suggestion_runs.py
@@ -1,0 +1,55 @@
+"""health_ai_suggestion_runs
+
+Revision ID: 0041_health_ai_suggestion_runs
+Revises: 0040_task_overdue_history
+Create Date: 2026-01-26
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0041_health_ai_suggestion_runs"
+down_revision = "0040_task_overdue_history"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'health')
+        BEGIN
+            EXEC('CREATE SCHEMA health')
+        END
+        """
+    )
+    op.create_table(
+        "ai_suggestion_runs",
+        sa.Column("Id", sa.Integer(), nullable=False),
+        sa.Column("UserId", sa.Integer(), nullable=False),
+        sa.Column("RunDate", sa.Date(), nullable=False),
+        sa.Column("SuggestionsGenerated", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("ModelUsed", sa.String(80), nullable=True),
+        sa.Column("NotificationSent", sa.Boolean(), nullable=False, server_default="0"),
+        sa.Column("ErrorMessage", sa.Text(), nullable=True),
+        sa.Column("CreatedAt", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("Id"),
+        sa.UniqueConstraint("UserId", "RunDate", name="uq_health_ai_suggestion_runs_user_date"),
+        schema="health",
+    )
+    op.create_index(
+        "ix_health_ai_suggestion_runs_user_date",
+        "ai_suggestion_runs",
+        ["UserId", "RunDate"],
+        unique=False,
+        schema="health",
+    )
+    # Note: Grant skipped for dev; apply manually in prod if needed
+    # GRANT SELECT, INSERT, UPDATE, DELETE ON health.ai_suggestion_runs TO EverdayCrud
+
+
+def downgrade() -> None:
+    op.drop_index("ix_health_ai_suggestion_runs_user_date", table_name="ai_suggestion_runs", schema="health")
+    op.drop_table("ai_suggestion_runs", schema="health")

--- a/backend/alembic/versions/0042_health_ai_suggestions_storage.py
+++ b/backend/alembic/versions/0042_health_ai_suggestions_storage.py
@@ -1,0 +1,54 @@
+"""health_ai_suggestions_storage
+
+Revision ID: 0042_health_ai_suggestions_storage
+Revises: 0041_health_ai_suggestion_runs
+Create Date: 2026-01-26
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0042_health_ai_suggestions_storage"
+down_revision = "0041_health_ai_suggestion_runs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'health')
+        BEGIN
+            EXEC('CREATE SCHEMA health')
+        END
+        """
+    )
+    op.create_table(
+        "ai_suggestions",
+        sa.Column("Id", sa.Integer(), nullable=False),
+        sa.Column("UserId", sa.Integer(), nullable=False),
+        sa.Column("RunId", sa.Integer(), nullable=False),
+        sa.Column("SuggestionType", sa.String(40), nullable=False, server_default="AiSuggestion"),
+        sa.Column("Title", sa.String(200), nullable=False),
+        sa.Column("Detail", sa.Text(), nullable=False),
+        sa.Column("CreatedAt", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("Id"),
+        sa.ForeignKeyConstraint(["RunId"], ["health.ai_suggestion_runs.Id"], ondelete="CASCADE"),
+        schema="health",
+    )
+    op.create_index(
+        "ix_health_ai_suggestions_user_run",
+        "ai_suggestions",
+        ["UserId", "RunId"],
+        unique=False,
+        schema="health",
+    )
+    # Note: Grant skipped for dev; apply manually in prod if needed
+    # GRANT SELECT, INSERT, UPDATE, DELETE ON health.ai_suggestions TO EverdayCrud
+
+
+def downgrade() -> None:
+    op.drop_index("ix_health_ai_suggestions_user_run", table_name="ai_suggestions", schema="health")
+    op.drop_table("ai_suggestions", schema="health")

--- a/backend/app/modules/health/models.py
+++ b/backend/app/modules/health/models.py
@@ -244,3 +244,33 @@ class MetricEntry(Base):
     OccurredAt = Column(DateTime(timezone=True), nullable=False)
     Source = Column(String(20), nullable=False)
     CreatedAt = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+
+
+class AiSuggestionRun(Base):
+    __tablename__ = "ai_suggestion_runs"
+    __table_args__ = (
+        UniqueConstraint("UserId", "RunDate", name="uq_health_ai_suggestion_runs_user_date"),
+        {"schema": "health"},
+    )
+
+    Id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    UserId = Column(Integer, nullable=False, index=True)
+    RunDate = Column(Date, nullable=False)
+    SuggestionsGenerated = Column(Integer, nullable=False, default=0)
+    ModelUsed = Column(String(80))
+    NotificationSent = Column(Boolean, nullable=False, default=False)
+    ErrorMessage = Column(Text)
+    CreatedAt = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+
+
+class AiSuggestion(Base):
+    __tablename__ = "ai_suggestions"
+    __table_args__ = {"schema": "health"}
+
+    Id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    UserId = Column(Integer, nullable=False, index=True)
+    RunId = Column(Integer, nullable=False, index=True)
+    SuggestionType = Column(String(40), nullable=False, default="AiSuggestion")
+    Title = Column(String(200), nullable=False)
+    Detail = Column(Text, nullable=False)
+    CreatedAt = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)

--- a/backend/app/modules/health/routes/suggestions.py
+++ b/backend/app/modules/health/routes/suggestions.py
@@ -3,8 +3,14 @@ from sqlalchemy.orm import Session
 
 from app.db import GetDb
 from app.modules.auth.deps import RequireModuleRole, UserContext
-from app.modules.health.schemas import SuggestionsResponse
+from app.modules.health.schemas import DailyAiSuggestionsRunResponse, SuggestionsResponse
 from app.modules.health.services.ai_suggestions_service import GetAiSuggestions
+from app.modules.health.services.daily_ai_service import RunDailyAiSuggestions
+
+
+def _IsAdmin(user: UserContext) -> bool:
+    return user.Role == "Admin"
+
 
 router = APIRouter()
 
@@ -18,5 +24,19 @@ def GetAiSuggestionsRoute(
     try:
         suggestions, model_used = GetAiSuggestions(db, user.Id, log_date)
         return SuggestionsResponse(Suggestions=suggestions, ModelUsed=model_used)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/ai/run-daily", response_model=DailyAiSuggestionsRunResponse)
+def RunDailyAiSuggestionsRoute(
+    db: Session = Depends(GetDb),
+    user: UserContext = Depends(RequireModuleRole("health", write=False)),
+) -> DailyAiSuggestionsRunResponse:
+    if not _IsAdmin(user):
+        raise HTTPException(status_code=403, detail="Access denied")
+    try:
+        result = RunDailyAiSuggestions(db, user.Id)
+        return DailyAiSuggestionsRunResponse(**result)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/modules/health/schemas.py
+++ b/backend/app/modules/health/schemas.py
@@ -341,6 +341,13 @@ class SuggestionsResponse(BaseModel):
     ModelUsed: str | None = None
 
 
+class DailyAiSuggestionsRunResponse(BaseModel):
+    EligibleUsers: int
+    SuggestionsGenerated: int
+    NotificationsSent: int
+    Errors: int
+
+
 class DailyLogWithEntries(BaseModel):
     DailyLog: DailyLog
     Entries: list[MealEntryWithFood]

--- a/backend/app/modules/health/services/daily_ai_service.py
+++ b/backend/app/modules/health/services/daily_ai_service.py
@@ -1,0 +1,178 @@
+"""
+Service for running automated daily AI suggestions at 6am.
+For parent-role users who have logged several meals over several days in the last 7 days.
+"""
+
+from datetime import date, timedelta
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.modules.auth.deps import NowUtc
+from app.modules.auth.models import User
+from app.modules.health.models import AiSuggestionRun, DailyLog, MealEntry
+from app.modules.health.services.ai_suggestions_service import GetAiSuggestions
+from app.modules.notifications.services import CreateNotification
+
+
+MINIMUM_MEAL_COUNT = 6  # Several meals
+MINIMUM_DAY_COUNT = 3  # Several days
+LOOKBACK_DAYS = 7
+
+
+def _IsEligibleForSuggestions(db: Session, user_id: int, run_date: date) -> bool:
+    """Check if user has logged enough data in last 7 days to warrant suggestions."""
+    start_date = run_date - timedelta(days=LOOKBACK_DAYS - 1)
+    
+    # Count distinct days with meal entries
+    days_logged_query = (
+        db.query(func.count(func.distinct(DailyLog.LogDate)))
+        .join(MealEntry, MealEntry.DailyLogId == DailyLog.DailyLogId)
+        .filter(
+            DailyLog.UserId == user_id,
+            DailyLog.LogDate >= start_date,
+            DailyLog.LogDate <= run_date,
+        )
+    )
+    days_logged = days_logged_query.scalar() or 0
+    
+    if days_logged < MINIMUM_DAY_COUNT:
+        return False
+    
+    # Count total meal entries
+    meal_count_query = (
+        db.query(func.count(MealEntry.MealEntryId))
+        .join(DailyLog, DailyLog.DailyLogId == MealEntry.DailyLogId)
+        .filter(
+            DailyLog.UserId == user_id,
+            DailyLog.LogDate >= start_date,
+            DailyLog.LogDate <= run_date,
+        )
+    )
+    meal_count = meal_count_query.scalar() or 0
+    
+    return meal_count >= MINIMUM_MEAL_COUNT
+
+
+def _HasAlreadyRun(db: Session, user_id: int, run_date: date) -> bool:
+    """Check if suggestions have already been generated for this user today."""
+    existing = (
+        db.query(AiSuggestionRun)
+        .filter(
+            AiSuggestionRun.UserId == user_id,
+            AiSuggestionRun.RunDate == run_date,
+        )
+        .first()
+    )
+    return existing is not None
+
+
+def _RecordRun(
+    db: Session,
+    user_id: int,
+    run_date: date,
+    suggestions_count: int,
+    model_used: str | None,
+    notification_sent: bool,
+    error_message: str | None = None,
+) -> AiSuggestionRun:
+    """Record that a suggestion run was performed."""
+    now = NowUtc()
+    record = AiSuggestionRun(
+        UserId=user_id,
+        RunDate=run_date,
+        SuggestionsGenerated=suggestions_count,
+        ModelUsed=model_used,
+        NotificationSent=notification_sent,
+        ErrorMessage=error_message,
+        CreatedAt=now,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+def RunDailyAiSuggestions(db: Session, admin_user_id: int, run_date: date | None = None) -> dict:
+    """
+    Run AI suggestions for all eligible parent users.
+    
+    Returns dict with:
+    - EligibleUsers: number of users who met criteria
+    - SuggestionsGenerated: number of users who got suggestions
+    - NotificationsSent: number of notifications sent
+    - Errors: number of failures
+    """
+    if run_date is None:
+        run_date = NowUtc().date()
+    
+    # Get all parent-role users
+    parent_users = db.query(User).filter(User.Role == "Parent").all()
+    
+    eligible_count = 0
+    suggestions_count = 0
+    notifications_count = 0
+    error_count = 0
+    
+    for user in parent_users:
+        # Skip if already ran today
+        if _HasAlreadyRun(db, user.Id, run_date):
+            continue
+        
+        # Check eligibility
+        if not _IsEligibleForSuggestions(db, user.Id, run_date):
+            continue
+        
+        eligible_count += 1
+        
+        try:
+            # Generate suggestions
+            suggestions, model_used = GetAiSuggestions(db, user.Id, run_date.isoformat())
+            suggestions_generated = len(suggestions)
+            
+            # Create notification
+            CreateNotification(
+                db,
+                user_id=user.Id,
+                created_by_user_id=admin_user_id,
+                title="Your daily health insights are ready",
+                body=f"We've prepared {suggestions_generated} personalized suggestions based on your recent activity.",
+                notification_type="HealthAiSuggestion",
+                link_url="/health/insights#ai-suggestions",
+                action_label="View suggestions",
+                source_module="health",
+                source_id=f"ai-suggestions-{run_date.isoformat()}",
+            )
+            
+            # Record successful run
+            _RecordRun(
+                db,
+                user.Id,
+                run_date,
+                suggestions_generated,
+                model_used,
+                notification_sent=True,
+            )
+            
+            suggestions_count += 1
+            notifications_count += 1
+            
+        except Exception as exc:  # noqa: BLE001
+            error_message = str(exc)
+            # Record failed run
+            _RecordRun(
+                db,
+                user.Id,
+                run_date,
+                0,
+                None,
+                notification_sent=False,
+                error_message=error_message,
+            )
+            error_count += 1
+    
+    return {
+        "EligibleUsers": eligible_count,
+        "SuggestionsGenerated": suggestions_count,
+        "NotificationsSent": notifications_count,
+        "Errors": error_count,
+    }


### PR DESCRIPTION
- Add automated daily AI suggestion generation for eligible parent users
- Eligibility: 6+ meals over 3+ days in last 7 days
- Store suggestions in database for cross-device sync
- Create notifications when suggestions are generated
- Add deep-link support to insights page anchor
- Admin-only endpoint to trigger daily runs
- Track run history per user/date

Backend:
- Migration 0041: ai_suggestion_runs table (track run history)
- Migration 0042: ai_suggestions table (store content)
- New service: daily_ai_service.py for automated runs
- Updated GetAiSuggestions to check DB first, save after generation
- New endpoint: POST /api/health/suggestions/ai/run-daily

Frontend:
- Add id='ai-suggestions' anchor for deep-linking
- Update to fetch from API with localStorage cache fallback
- Supports cross-device suggestion sync

Docs:
- Add migration patterns to AGENTS.md
- Add notification deep-linking patterns
- Add automated run patterns