### PR TITLE
feat: expose system settings for kids

### DIFF
--- a/apps/ios/EverdayIOS/EverdayIOS/Views/SettingsView.swift
+++ b/apps/ios/EverdayIOS/EverdayIOS/Views/SettingsView.swift
@@ -22,12 +22,12 @@ struct SettingsView: View {
                         Label("Health settings", systemImage: "heart.text.square")
                     }
                 }
-                Section("System") {
-                    NavigationLink {
-                        SystemSettingsView()
-                    } label: {
-                        Label("System settings", systemImage: "gearshape")
-                    }
+            }
+            Section("System") {
+                NavigationLink {
+                    SystemSettingsView()
+                } label: {
+                    Label("System settings", systemImage: "gearshape")
                 }
             }
         }


### PR DESCRIPTION
Allow kids to access System settings so they can switch between DEV and PROD environments when needed.

Fixes #124