### PR TITLE
Add health dashboard API

### DIFF
--- a/backend/alembic/versions/0072_auth_api_tokens.py
+++ b/backend/alembic/versions/0072_auth_api_tokens.py
@@ -1,0 +1,40 @@
+"""add scoped API tokens
+
+Revision ID: 0072_auth_api_tokens
+Revises: 0071_health_meal_entry_nutrition
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0072_auth_api_tokens"
+down_revision = "0071_health_meal_entry_nutrition"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_tokens",
+        sa.Column("Id", sa.String(length=36), nullable=False),
+        sa.Column("UserId", sa.Integer(), nullable=False),
+        sa.Column("Name", sa.String(length=100), nullable=False),
+        sa.Column("TokenHash", sa.String(length=255), nullable=False),
+        sa.Column("LookupHash", sa.String(length=64), nullable=False),
+        sa.Column("Scopes", sa.Text(), nullable=False),
+        sa.Column("CreatedAt", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ExpiresAt", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("LastUsedAt", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("RevokedAt", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["UserId"], ["auth.users.Id"]),
+        sa.PrimaryKeyConstraint("Id"),
+        sa.UniqueConstraint("LookupHash"),
+        schema="auth",
+    )
+    op.create_index("ix_auth_api_tokens_user_id", "api_tokens", ["UserId"], unique=False, schema="auth")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_auth_api_tokens_user_id", table_name="api_tokens", schema="auth")
+    op.drop_table("api_tokens", schema="auth")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -33,6 +34,8 @@ from app.modules.tasks.router import router as tasks_router
 from app.modules.integrations.google.router import router as google_router
 from app.modules.integrations.gmail.router import router as gmail_router
 from app.modules.integrations.health_mcp.router import router as health_mcp_router
+from app.modules.health.routes.dashboard_api import router as health_dashboard_api_router
+from app.modules.auth.api_tokens import ApiTokenRequestError
 from app.modules.integrations.gmail.models import GmailIntegration
 from app.modules.notes.routes.notes import router as notes_router
 from app.modules.health.services.reminders_service import RunDailyHealthReminders
@@ -63,6 +66,11 @@ _daily_tips_task: asyncio.Task | None = None
 _daily_tips_stop_event = asyncio.Event()
 _gmail_intake_task: asyncio.Task | None = None
 _gmail_intake_stop_event = asyncio.Event()
+
+
+@app.exception_handler(ApiTokenRequestError)
+async def api_token_request_error(_request: Request, exc: ApiTokenRequestError) -> JSONResponse:
+    return JSONResponse(status_code=exc.status_code, content={"error": {"code": exc.code, "message": exc.message}})
 
 allowed_origins = os.getenv("ALLOWED_ORIGINS", "").strip()
 if not allowed_origins:
@@ -203,6 +211,7 @@ app.include_router(tasks_router)
 app.include_router(google_router)
 app.include_router(gmail_router)
 app.include_router(health_mcp_router)
+app.include_router(health_dashboard_api_router)
 app.include_router(notes_router)
 
 class SpaStaticFiles(StaticFiles):

--- a/backend/app/modules/auth/api_tokens.py
+++ b/backend/app/modules/auth/api_tokens.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from app.db import GetDb
+from app.modules.auth.deps import NowUtc
+from app.modules.auth.models import ApiToken, User
+from app.modules.auth.service import HashApiKey, VerifyApiKey
+
+
+HEALTH_DASHBOARD_READ_SCOPE = "health:dashboard:read"
+
+
+class ApiTokenRequestError(Exception):
+    def __init__(self, status_code: int, code: str, message: str) -> None:
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class ApiTokenContext:
+    TokenId: str
+    UserId: int
+    Scopes: frozenset[str]
+
+
+def _LookupHash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _ParseScopes(value: str) -> frozenset[str]:
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return frozenset()
+    if not isinstance(parsed, list):
+        return frozenset()
+    return frozenset(str(item) for item in parsed if isinstance(item, str))
+
+
+def CreateApiToken(
+    db: Session,
+    user_id: int,
+    name: str,
+    scopes: set[str],
+    expires_at: datetime | None = None,
+) -> tuple[ApiToken, str]:
+    cleaned_name = " ".join(name.split())
+    if not cleaned_name or len(cleaned_name) > 100:
+        raise ValueError("Token name must be between 1 and 100 characters.")
+    if not scopes:
+        raise ValueError("At least one scope is required.")
+
+    plaintext = f"evd_{secrets.token_urlsafe(32)}"
+    record = ApiToken(
+        Id=str(uuid.uuid4()),
+        UserId=user_id,
+        Name=cleaned_name,
+        TokenHash=HashApiKey(plaintext),
+        LookupHash=_LookupHash(plaintext),
+        Scopes=json.dumps(sorted(scopes)),
+        CreatedAt=NowUtc(),
+        ExpiresAt=expires_at,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record, plaintext
+
+
+def RevokeApiToken(db: Session, token_id: str, user_id: int | None = None) -> bool:
+    query = db.query(ApiToken).filter(ApiToken.Id == token_id)
+    if user_id is not None:
+        query = query.filter(ApiToken.UserId == user_id)
+    record = query.first()
+    if record is None or record.RevokedAt is not None:
+        return False
+    record.RevokedAt = NowUtc()
+    db.add(record)
+    db.commit()
+    return True
+
+
+def ListApiTokens(db: Session, user_id: int) -> list[ApiToken]:
+    return db.query(ApiToken).filter(ApiToken.UserId == user_id).order_by(ApiToken.CreatedAt.desc()).all()
+
+
+def _Unauthorized() -> ApiTokenRequestError:
+    return ApiTokenRequestError(status.HTTP_401_UNAUTHORIZED, "unauthorised", "A valid API token is required.")
+
+
+def RequireApiToken(required_scope: str):
+    def _checker(request: Request, db: Session = Depends(GetDb)) -> ApiTokenContext:
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            raise _Unauthorized()
+        plaintext = auth_header.removeprefix("Bearer ").strip()
+        if not plaintext.startswith("evd_") or not plaintext:
+            raise _Unauthorized()
+
+        record = db.query(ApiToken).filter(ApiToken.LookupHash == _LookupHash(plaintext)).first()
+        now = NowUtc()
+        if (
+            record is None
+            or record.RevokedAt is not None
+            or (record.ExpiresAt is not None and record.ExpiresAt <= now)
+            or not VerifyApiKey(plaintext, record.TokenHash)
+        ):
+            raise _Unauthorized()
+
+        scopes = _ParseScopes(record.Scopes)
+        if required_scope not in scopes:
+            raise ApiTokenRequestError(
+                status.HTTP_403_FORBIDDEN, "forbidden", "API token lacks the required scope."
+            )
+
+        user = db.query(User).filter(User.Id == record.UserId).first()
+        if user is None or user.IsApproved == False:
+            raise _Unauthorized()
+
+        record.LastUsedAt = now
+        db.add(record)
+        db.commit()
+        return ApiTokenContext(TokenId=record.Id, UserId=user.Id, Scopes=scopes)
+
+    return _checker

--- a/backend/app/modules/auth/models.py
+++ b/backend/app/modules/auth/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, Numeric, String
+from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, Numeric, String, Text
 from sqlalchemy.orm import relationship
 
 from app.db import Base
@@ -76,3 +76,21 @@ class PasswordResetToken(Base):
     CreatedAt = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
 
     User = relationship("User", back_populates="PasswordResetTokens")
+
+
+class ApiToken(Base):
+    __tablename__ = "api_tokens"
+    __table_args__ = {"schema": "auth"}
+
+    Id = Column(String(36), primary_key=True)
+    UserId = Column(Integer, ForeignKey("auth.users.Id"), nullable=False, index=True)
+    Name = Column(String(100), nullable=False)
+    TokenHash = Column(String(255), nullable=False)
+    LookupHash = Column(String(64), nullable=False, unique=True, index=True)
+    Scopes = Column(Text, nullable=False)
+    CreatedAt = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    ExpiresAt = Column(DateTime(timezone=True))
+    LastUsedAt = Column(DateTime(timezone=True))
+    RevokedAt = Column(DateTime(timezone=True))
+
+    User = relationship("User")

--- a/backend/app/modules/health/routes/dashboard_api.py
+++ b/backend/app/modules/health/routes/dashboard_api.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+from fastapi import APIRouter, Depends, Query, Request, status
+from sqlalchemy.orm import Session
+
+from app.db import GetDb
+from app.modules.auth.api_tokens import (
+    ApiTokenContext,
+    ApiTokenRequestError,
+    HEALTH_DASHBOARD_READ_SCOPE,
+    RequireApiToken,
+)
+from app.modules.health.services.dashboard_api_service import BuildDashboardResponse
+
+
+router = APIRouter(prefix="/api/v1/health", tags=["health-dashboard-api"])
+logger = logging.getLogger("health.dashboard_api")
+
+
+class _TokenRateLimiter:
+    def __init__(self, limit: int, window_seconds: int) -> None:
+        self._limit = limit
+        self._window_seconds = window_seconds
+        self._requests: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+
+    def allow(self, token_id: str) -> bool:
+        now = time.monotonic()
+        with self._lock:
+            threshold = now - self._window_seconds
+            for key, values in list(self._requests.items()):
+                active_values = [value for value in values if value > threshold]
+                if active_values:
+                    self._requests[key] = active_values
+                else:
+                    self._requests.pop(key, None)
+            timestamps = self._requests.get(token_id, [])
+            if len(timestamps) >= self._limit:
+                self._requests[token_id] = timestamps
+                return False
+            timestamps.append(now)
+            self._requests[token_id] = timestamps
+            return True
+
+
+rate_limiter = _TokenRateLimiter(limit=60, window_seconds=3600)
+
+
+def _Window(value: str, *, name: str, default: int, maximum: int) -> int:
+    candidate = value or str(default)
+    try:
+        parsed = int(candidate)
+    except (TypeError, ValueError) as exc:
+        raise ApiTokenRequestError(status.HTTP_400_BAD_REQUEST, "invalid_parameter", f"{name} must be an integer.") from exc
+    if not 7 <= parsed <= maximum:
+        raise ApiTokenRequestError(
+            status.HTTP_400_BAD_REQUEST, "invalid_parameter", f"{name} must be between 7 and {maximum}."
+        )
+    return parsed
+
+
+@router.get("/dashboard")
+def GetDashboardApi(
+    request: Request,
+    weightDays: str = Query(default="90"),
+    stepDays: str = Query(default="30"),
+    daySummaryDays: str = Query(default="14"),
+    db: Session = Depends(GetDb),
+    token: ApiTokenContext = Depends(RequireApiToken(HEALTH_DASHBOARD_READ_SCOPE)),
+) -> dict:
+    if not rate_limiter.allow(token.TokenId):
+        raise ApiTokenRequestError(status.HTTP_429_TOO_MANY_REQUESTS, "rate_limited", "Rate limit exceeded.")
+    weight_days = _Window(weightDays, name="weightDays", default=90, maximum=365)
+    step_days = _Window(stepDays, name="stepDays", default=30, maximum=365)
+    day_summary_days = _Window(daySummaryDays, name="daySummaryDays", default=14, maximum=90)
+    started = time.perf_counter()
+    try:
+        response = BuildDashboardResponse(
+            db,
+            token.UserId,
+            weight_days=weight_days,
+            step_days=step_days,
+            day_summary_days=day_summary_days,
+        )
+        logger.info(
+            "dashboard API token_id=%s user_id=%s status=200 duration_ms=%s ip=%s",
+            token.TokenId,
+            token.UserId,
+            int((time.perf_counter() - started) * 1000),
+            request.client.host if request.client else "unknown",
+        )
+        return response
+    except Exception:
+        logger.exception("dashboard API token_id=%s user_id=%s status=500", token.TokenId, token.UserId)
+        raise ApiTokenRequestError(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "internal_error",
+            "The dashboard data could not be loaded.",
+        ) from None

--- a/backend/app/modules/health/services/dashboard_api_service.py
+++ b/backend/app/modules/health/services/dashboard_api_service.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from sqlalchemy.orm import Session
+
+from app.modules.health.services.daily_logs_service import GetWeightHistory
+from app.modules.health.services.settings_service import GetUserSettings
+from app.modules.health.services.summary_service import GetWeeklySummary
+from app.modules.integrations.health_mcp.service import GetHistory, GetSummary
+
+
+def _UserZone(timezone_name: str | None) -> ZoneInfo:
+    try:
+        return ZoneInfo(timezone_name or "Australia/Adelaide")
+    except ZoneInfoNotFoundError:
+        return ZoneInfo("Australia/Adelaide")
+
+
+def _Number(value: object, digits: int = 1) -> float | int | None:
+    if value is None:
+        return None
+    return round(float(value), digits)
+
+
+def BuildDashboardResponse(
+    db: Session,
+    user_id: int,
+    *,
+    weight_days: int,
+    step_days: int,
+    day_summary_days: int,
+) -> dict:
+    settings = GetUserSettings(db, user_id)
+    zone = _UserZone(settings.ReminderTimeZone)
+    today = datetime.now(zone).date()
+    today_text = today.isoformat()
+    week_start = today - timedelta(days=today.weekday())
+    week_end = week_start + timedelta(days=6)
+
+    today_snapshot = GetSummary(db, user_id, today_text)
+    weekly = GetWeeklySummary(db, user_id, week_start.isoformat())
+    weights = GetWeightHistory(db, user_id, (today - timedelta(days=weight_days - 1)).isoformat(), today_text)
+    steps = GetHistory(db, user_id, "steps", (today - timedelta(days=step_days - 1)).isoformat(), today_text)
+    days = GetHistory(db, user_id, "days", (today - timedelta(days=day_summary_days - 1)).isoformat(), today_text)
+    current_week_days = [
+        item for item in days if week_start.isoformat() <= item["LogDate"] <= week_end.isoformat()
+    ]
+    sleep_values = [float(item["SleepHours"]) for item in current_week_days if item["SleepHours"] is not None]
+
+    log = today_snapshot["DailyLog"]
+    totals = today_snapshot["Totals"]
+    summary = today_snapshot["Summary"]
+    targets = settings.Targets
+    goal = settings.Goal
+    weight_change = None
+    if len(weights) >= 2:
+        weight_change = round(float(weights[-1].WeightKg) - float(weights[0].WeightKg), 2)
+
+    return {
+        "apiVersion": "1",
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "timezone": zone.key,
+        "goal": None if goal is None else {
+            "type": goal.GoalType.value,
+            "status": goal.Status,
+            "startDate": goal.StartDate.isoformat(),
+            "endDate": goal.EndDate.isoformat(),
+            "currentWeightKg": _Number(goal.CurrentWeightKg, 2),
+            "targetWeightKg": _Number(goal.TargetWeightKg, 2),
+            "remainingKg": round(abs(float(goal.TargetWeightKg) - float(goal.CurrentWeightKg)), 2),
+            "currentBmi": _Number(goal.CurrentBmi, 2),
+            "targetBmi": _Number(goal.TargetBmi, 2),
+            "remainingDays": goal.RemainingDays,
+        },
+        "targets": {
+            "dailyCalories": targets.DailyCalorieTarget,
+            "proteinMinG": _Number(targets.ProteinTargetMin),
+            "proteinMaxG": _Number(targets.ProteinTargetMax),
+            "dailySteps": targets.StepTarget,
+            "fibreG": _Number(targets.FibreTarget),
+        },
+        "today": {
+            "date": today_text,
+            "calories": totals.TotalCalories,
+            "remainingCalories": totals.RemainingCalories,
+            "proteinG": _Number(totals.TotalProtein),
+            "remainingProteinMinG": _Number(totals.RemainingProteinMin),
+            "steps": summary.Steps if log is not None else None,
+            "sleepHours": _Number(log.SleepHours, 2) if log is not None else None,
+            "workoutCount": summary.WorkoutCount,
+            "loggingComplete": bool(log.LoggedComplete) if log is not None and log.LoggedComplete is not None else False,
+        },
+        "currentWeek": {
+            "weekStart": week_start.isoformat(),
+            "weekEnd": week_end.isoformat(),
+            "averageCalories": weekly.Averages["AverageCalories"],
+            "averageProteinG": weekly.Averages["AverageProtein"],
+            "averageSteps": weekly.Averages["AverageSteps"],
+            "averageSleepHours": _Number(sum(sleep_values) / len(sleep_values), 2) if sleep_values else None,
+            "weightChangeKg": weight_change,
+        },
+        "weightHistory": [{"date": item.LogDate.isoformat(), "weightKg": _Number(item.WeightKg, 2)} for item in weights],
+        "stepHistory": [{"date": item["LogDate"], "steps": item["Steps"]} for item in steps],
+        "dailySummaries": [
+            {
+                "date": item["LogDate"], "calories": item["TotalCalories"], "proteinG": _Number(item["TotalProtein"]),
+                "fibreG": _Number(item["TotalFibre"]), "steps": item["Steps"],
+                "sleepHours": _Number(item["SleepHours"], 2), "weightKg": _Number(item["WeightKg"], 2),
+                "workoutCount": item["WorkoutCount"], "loggingComplete": item["LoggedComplete"],
+            }
+            for item in days
+        ],
+    }

--- a/backend/scripts/api_tokens.py
+++ b/backend/scripts/api_tokens.py
@@ -1,0 +1,72 @@
+"""Manage scoped Everday API tokens from inside the Everday container.
+
+Plaintext tokens are printed only by the create command. Do not redirect its
+output to a committed file or paste it into logs.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+
+import app.db as db_module
+from app.modules.auth.api_tokens import CreateApiToken, HEALTH_DASHBOARD_READ_SCOPE, ListApiTokens, RevokeApiToken
+from app.modules.auth.models import User
+
+
+def _UserId(db, username: str) -> int:
+    user = db.query(User).filter(User.Username == username).first()
+    if user is None:
+        raise SystemExit("User not found.")
+    return int(user.Id)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage scoped Everday API tokens.")
+    commands = parser.add_subparsers(dest="command", required=True)
+    create = commands.add_parser("create")
+    create.add_argument("--user", required=True)
+    create.add_argument("--name", required=True)
+    create.add_argument("--expires-at", help="Optional ISO-8601 timestamp.")
+    listing = commands.add_parser("list")
+    listing.add_argument("--user", required=True)
+    revoke = commands.add_parser("revoke")
+    revoke.add_argument("--user", required=True)
+    revoke.add_argument("--token-id", required=True)
+    args = parser.parse_args()
+
+    db_module._ensure_engine()
+    if db_module.SessionLocal is None:
+        raise RuntimeError("Database session factory is unavailable.")
+    db = db_module.SessionLocal()
+    try:
+        user_id = _UserId(db, args.user)
+        if args.command == "create":
+            expires_at = datetime.fromisoformat(args.expires_at) if args.expires_at else None
+            if expires_at is not None and expires_at.tzinfo is None:
+                raise SystemExit("--expires-at must include an explicit timezone offset.")
+            if expires_at is not None:
+                expires_at = expires_at.astimezone(timezone.utc)
+            record, plaintext = CreateApiToken(
+                db, user_id, args.name, {HEALTH_DASHBOARD_READ_SCOPE}, expires_at=expires_at
+            )
+            print(f"Token ID: {record.Id}")
+            print(f"Token: {plaintext}")
+            return
+        if args.command == "list":
+            for record in ListApiTokens(db, user_id):
+                print(
+                    f"{record.Id}\t{record.Name}\t{record.Scopes}\t"
+                    f"created={record.CreatedAt}\texpires={record.ExpiresAt}\t"
+                    f"last_used={record.LastUsedAt}\trevoked={record.RevokedAt}"
+                )
+            return
+        if not RevokeApiToken(db, args.token_id, user_id):
+            raise SystemExit("Active token not found.")
+        print("Token revoked.")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/api_tokens.py
+++ b/backend/scripts/api_tokens.py
@@ -7,6 +7,7 @@ output to a committed file or paste it into logs.
 from __future__ import annotations
 
 import argparse
+import os
 from datetime import datetime, timezone
 
 import app.db as db_module
@@ -51,7 +52,9 @@ def main() -> None:
                 db, user_id, args.name, {HEALTH_DASHBOARD_READ_SCOPE}, expires_at=expires_at
             )
             print(f"Token ID: {record.Id}")
-            print(f"Token: {plaintext}")
+            # This is an intentional one-time operator hand-off, not application logging.
+            # Write directly to the invoking terminal so the token never reaches a logger.
+            os.write(1, f"Token: {plaintext}\n".encode("utf-8"))
             return
         if args.command == "list":
             for record in ListApiTokens(db, user_id):

--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -1,0 +1,74 @@
+from datetime import date
+from types import SimpleNamespace
+
+from app.modules.auth import api_tokens
+from app.modules.health.routes.dashboard_api import _TokenRateLimiter, _Window
+from app.modules.health.services import dashboard_api_service
+
+
+def test_api_token_format_and_lookup_hash_are_stable() -> None:
+    token = "evd_example-token"
+    assert api_tokens._LookupHash(token) == api_tokens._LookupHash(token)
+    assert api_tokens._ParseScopes('["health:dashboard:read"]') == {"health:dashboard:read"}
+    assert api_tokens._ParseScopes("not-json") == set()
+
+
+def test_dashboard_windows_reject_out_of_range_values() -> None:
+    assert _Window("90", name="weightDays", default=90, maximum=365) == 90
+    try:
+        _Window("366", name="weightDays", default=90, maximum=365)
+    except api_tokens.ApiTokenRequestError as exc:
+        assert exc.status_code == 400
+    else:
+        raise AssertionError("Expected invalid parameter error")
+
+
+def test_rate_limiter_drops_expired_token_records(monkeypatch) -> None:
+    limiter = _TokenRateLimiter(limit=1, window_seconds=60)
+    monkeypatch.setattr("app.modules.health.routes.dashboard_api.time.monotonic", lambda: 100.0)
+    assert limiter.allow("retired-token") is True
+    monkeypatch.setattr("app.modules.health.routes.dashboard_api.time.monotonic", lambda: 161.0)
+    assert limiter.allow("fresh-token") is True
+    assert "retired-token" not in limiter._requests
+
+
+def test_dashboard_response_excludes_notes_and_meal_details(monkeypatch) -> None:
+    target = SimpleNamespace(
+        DailyCalorieTarget=1600, ProteinTargetMin=100, ProteinTargetMax=120, StepTarget=7000, FibreTarget=30
+    )
+    settings = SimpleNamespace(ReminderTimeZone="Australia/Adelaide", Targets=target, Goal=None)
+    monkeypatch.setattr(dashboard_api_service, "GetUserSettings", lambda *_args: settings)
+    monkeypatch.setattr(
+        dashboard_api_service,
+        "GetSummary",
+        lambda *_args: {
+            "DailyLog": SimpleNamespace(SleepHours=7.5, LoggedComplete=False),
+            "Totals": SimpleNamespace(TotalCalories=450, RemainingCalories=1150, TotalProtein=23.7, RemainingProteinMin=76.3),
+            "Summary": SimpleNamespace(Steps=2235, WorkoutCount=0),
+        },
+    )
+    monkeypatch.setattr(
+        dashboard_api_service,
+        "GetWeeklySummary",
+        lambda *_args: SimpleNamespace(Averages={"AverageCalories": 1238, "AverageProtein": 63.4, "AverageSteps": 4522}),
+    )
+    monkeypatch.setattr(
+        dashboard_api_service,
+        "GetWeightHistory",
+        lambda *_args: [SimpleNamespace(LogDate=date(2026, 7, 26), WeightKg=94.6), SimpleNamespace(LogDate=date(2026, 7, 30), WeightKg=92.6)],
+    )
+    def history(_db, _user, kind, *_args):
+        if kind == "steps":
+            return [{"LogDate": "2026-07-30", "Steps": 4584}]
+        return [{"LogDate": "2026-07-30", "TotalCalories": 1355, "TotalProtein": 63.3, "TotalFibre": 16.1,
+                 "Steps": 4584, "SleepHours": 3.31, "WeightKg": 92.6, "WorkoutCount": 0,
+                 "LoggedComplete": False, "Notes": "must not escape"}]
+    monkeypatch.setattr(dashboard_api_service, "GetHistory", history)
+
+    response = dashboard_api_service.BuildDashboardResponse(None, 7, weight_days=90, step_days=30, day_summary_days=14)
+
+    assert response["targets"]["dailyCalories"] == 1600
+    assert response["weightHistory"][-1]["weightKg"] == 92.6
+    assert response["dailySummaries"][0]["sleepHours"] == 3.31
+    assert "Notes" not in response["dailySummaries"][0]
+    assert "Entries" not in response

--- a/docs/chatgpt-sites-health-dashboard.md
+++ b/docs/chatgpt-sites-health-dashboard.md
@@ -1,0 +1,68 @@
+# ChatGPT Sites health dashboard hand-off
+
+## Purpose
+
+Everday exposes a versioned, read-only dashboard API for a private ChatGPT Site.
+The Site must call Everday only from its server-side route. Do not send the
+Everday token to browser code.
+
+## Connection
+
+```text
+GET https://everday.batserver.au/api/v1/health/dashboard
+Authorization: Bearer ${EVERDAY_API_TOKEN}
+Accept: application/json
+```
+
+The endpoint accepts these optional query parameters:
+
+| Parameter | Default | Range |
+| --- | ---: | ---: |
+| `weightDays` | 90 | 7 to 365 |
+| `stepDays` | 30 | 7 to 365 |
+| `daySummaryDays` | 14 | 7 to 90 |
+
+The response includes `apiVersion`, `generatedAt`, the user timezone, goal,
+targets, today, current-week values, weight history, step history, and daily
+summaries. It deliberately excludes meal entries and free-text notes.
+
+## Site implementation requirements
+
+- Keep the Site private/owner-only using the platform’s built-in access control.
+- Create a server-side `/api/health` route that calls the Everday endpoint with
+  `Authorization: Bearer ${EVERDAY_API_TOKEN}`.
+- Store `EVERDAY_API_BASE_URL=https://everday.batserver.au` as a normal
+  environment variable and `EVERDAY_API_TOKEN` as a Site secret.
+- Use an 8 to 10 second upstream timeout and `Cache-Control: no-store` on the
+  browser response.
+- Return a generic upstream failure to the browser. Never return the Everday
+  token, upstream Authorization header, or raw authentication error.
+- Show `generatedAt` as the dashboard’s refresh time and retain the last
+  successful payload if a manual refresh fails.
+
+## OAuth
+
+OAuth is not required for version 1. The Site’s private viewer gate controls
+who can open the Site; the separate Everday token identifies the single
+read-only Everday account. Add OAuth only if the Site must support multiple
+Everday users or delegated access.
+
+## Operational commands
+
+Run these inside the Everday container after the migration is deployed:
+
+```bash
+python scripts/api_tokens.py create --user <everday-username> --name chatgpt-sites-health-dashboard
+python scripts/api_tokens.py list --user <everday-username>
+python scripts/api_tokens.py revoke --user <everday-username> --token-id <token-id>
+```
+
+The create command displays the plaintext token once. Store it only in the
+ChatGPT Site secret configuration. Revoke it immediately if exposed.
+
+## Security boundary
+
+The token is scoped only to `health:dashboard:read`, is stored by Everday as an
+Argon2 hash plus a SHA-256 lookup hash, can be revoked immediately, and is
+limited to 60 requests per token per hour. Existing Everday login, HAE import,
+Health dashboard, and Health MCP authentication are independent and unchanged.


### PR DESCRIPTION
## Summary
- add scoped read-only API tokens and dashboard endpoint
- keep existing HAE, dashboard, and MCP auth paths unchanged
- add ChatGPT Sites integration hand-off

## Verification
- ./scripts/dev.sh --build-only
- PYTHONPATH=/app pytest tests/ -v --tb=short (92 passed)
- independent peer review; resolved all findings