### PR TITLE
Feat: Discord reminder when yesterday's log is incomplete

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,7 +38,10 @@ from app.modules.health.routes.dashboard_api import router as health_dashboard_a
 from app.modules.auth.api_tokens import ApiTokenRequestError
 from app.modules.integrations.gmail.models import GmailIntegration
 from app.modules.notes.routes.notes import router as notes_router
-from app.modules.health.services.reminders_service import RunDailyHealthReminders
+from app.modules.health.services.reminders_service import (
+    RunDailyHealthReminders,
+    RunYesterdayLogReminders,
+)
 from app.modules.health.services.daily_tip_service import RunDailyTips
 from app.modules.kids.services.reminders_service import RunDailyKidsReminders
 from app.modules.life_admin import gmail_intake_service
@@ -367,12 +370,38 @@ async def _health_reminders_loop() -> None:
         except Exception:  # noqa: BLE001
             reminders_logger.exception("health reminders scheduler run failed")
 
+        # Runs off the event loop because it makes outbound Discord webhook calls.
+        try:
+            yesterday_result = await asyncio.to_thread(_run_yesterday_log_reminders)
+            sent = yesterday_result.get("NotificationsSent", 0)
+            errors = yesterday_result.get("Errors", 0)
+            if sent or errors:
+                reminders_logger.info(
+                    "yesterday log reminders run complete eligible=%s processed=%s sent=%s skipped=%s errors=%s",
+                    yesterday_result.get("EligibleUsers", 0),
+                    yesterday_result.get("ProcessedUsers", 0),
+                    sent,
+                    yesterday_result.get("Skipped", 0),
+                    errors,
+                )
+        except Exception:  # noqa: BLE001
+            reminders_logger.exception("yesterday log reminders scheduler run failed")
+
         elapsed_seconds = int(time.perf_counter() - started)
         sleep_for = max(1, interval_seconds - elapsed_seconds)
         try:
             await asyncio.wait_for(_reminders_stop_event.wait(), timeout=sleep_for)
         except asyncio.TimeoutError:
             continue
+
+
+def _run_yesterday_log_reminders() -> dict:
+    db_module._ensure_engine()
+    db = db_module.SessionLocal()
+    try:
+        return RunYesterdayLogReminders(db)
+    finally:
+        db.close()
 
 
 async def _kids_reminders_loop() -> None:

--- a/backend/app/modules/health/routes/settings.py
+++ b/backend/app/modules/health/routes/settings.py
@@ -27,7 +27,10 @@ from app.modules.health.services.settings_service import (
     UpdateSettings,
     UpdateUserProfile,
 )
-from app.modules.health.services.reminders_service import RunDailyHealthReminders
+from app.modules.health.services.reminders_service import (
+    RunDailyHealthReminders,
+    RunYesterdayLogReminders,
+)
 from app.modules.health.utils.rbac import IsParent
 
 router = APIRouter()
@@ -140,6 +143,25 @@ def RunHealthRemindersRoute(
         result = RunDailyHealthReminders(
             db,
             admin_user_id=user.Id,
+            run_date=payload.RunDate if payload else None,
+            run_time=payload.RunTime if payload else None,
+        )
+        return HealthReminderRunResponse(**result)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/reminders/run-yesterday-check", response_model=HealthReminderRunResponse)
+def RunYesterdayLogRemindersRoute(
+    payload: HealthReminderRunRequest | None = None,
+    db: Session = Depends(GetDb),
+    user: UserContext = Depends(RequireModuleRole("health", write=True)),
+) -> HealthReminderRunResponse:
+    if not _IsAdmin(user):
+        raise HTTPException(status_code=403, detail="Access denied")
+    try:
+        result = RunYesterdayLogReminders(
+            db,
             run_date=payload.RunDate if payload else None,
             run_time=payload.RunTime if payload else None,
         )

--- a/backend/app/modules/health/services/discord_service.py
+++ b/backend/app/modules/health/services/discord_service.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DiscordWebhookEnvPrefix = "DISCORD_"
+DiscordWebhookFallbackEnvPrefix = "HEALTH_DISCORD_WEBHOOK_USER_"
+DiscordSendTimeoutSeconds = 10.0
+DiscordMaxContentLength = 2000
+DiscordRetryStatuses = frozenset({429, 500, 502, 503, 504})
+DiscordMaxAttempts = 2
+DiscordMaxRetryDelaySeconds = 5.0
+
+
+def _EnvKeySuffix(username: str) -> str:
+    return re.sub(r"[^A-Z0-9]+", "_", username.strip().upper()).strip("_")
+
+
+def ResolveWebhookUrl(user_id: int, username: str | None = None) -> str | None:
+    """Return the configured Discord webhook for a user, or None when unset.
+
+    Resolves `DISCORD_<USERNAME>` first (for example `DISCORD_KEVIN`), then falls
+    back to `HEALTH_DISCORD_WEBHOOK_USER_<id>`.
+    """
+    candidates: list[str] = []
+    if username:
+        suffix = _EnvKeySuffix(username)
+        if suffix:
+            candidates.append(f"{DiscordWebhookEnvPrefix}{suffix}")
+    candidates.append(f"{DiscordWebhookFallbackEnvPrefix}{user_id}")
+
+    for key in candidates:
+        value = os.getenv(key, "").strip()
+        if value:
+            return value
+    return None
+
+
+def _RetryDelaySeconds(response: httpx.Response) -> float:
+    raw = response.headers.get("Retry-After", "")
+    try:
+        delay = float(raw)
+    except ValueError:
+        delay = 1.0
+    return min(max(delay, 0.0), DiscordMaxRetryDelaySeconds)
+
+
+def SendDiscordMessage(webhook_url: str, content: str) -> None:
+    """Post a plain-text message to a Discord webhook.
+
+    Raises on failure. Webhook URLs are secrets and are never logged.
+    """
+    body = content.strip()[:DiscordMaxContentLength]
+    if not body:
+        raise ValueError("Discord message content must not be empty.")
+
+    last_status: int | None = None
+    for attempt in range(1, DiscordMaxAttempts + 1):
+        with httpx.Client(timeout=DiscordSendTimeoutSeconds) as client:
+            response = client.post(webhook_url, json={"content": body})
+        if response.status_code < 400:
+            return
+        last_status = response.status_code
+        if attempt >= DiscordMaxAttempts or response.status_code not in DiscordRetryStatuses:
+            break
+        delay = _RetryDelaySeconds(response)
+        logger.warning(
+            "Discord webhook returned %s, retrying in %ss", response.status_code, delay
+        )
+        time.sleep(delay)
+
+    raise RuntimeError(f"Discord webhook returned {last_status}")

--- a/backend/app/modules/health/services/reminders_service.py
+++ b/backend/app/modules/health/services/reminders_service.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from sqlalchemy.orm import Session
@@ -20,6 +21,7 @@ from app.modules.health.utils.defaults import (
     DefaultWeightReminderTime,
 )
 from app.modules.notifications.services import CreateNotification
+from app.modules.health.services.discord_service import ResolveWebhookUrl, SendDiscordMessage
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +34,12 @@ MealTypeLabels = {
     "Snack3": "Snack 3",
 }
 DefaultReminderZone = ZoneInfo(DefaultReminderTimeZone)
+
+MainMealTypes = ("Breakfast", "Lunch", "Dinner")
+YesterdayReminderType = "YesterdayIncomplete"
+DefaultYesterdayWeekdayTime = "07:00"
+DefaultYesterdayWeekendTime = "09:00"
+DefaultHealthDashboardBaseUrl = "https://health.bunella.au"
 
 
 def _IsValidTime(value: str | None) -> bool:
@@ -449,6 +457,201 @@ def RunDailyHealthReminders(
             eligible_users += 1
         if user_processed:
             processed_users += 1
+
+    return {
+        "EligibleUsers": eligible_users,
+        "ProcessedUsers": processed_users,
+        "NotificationsSent": notifications_sent,
+        "Skipped": skipped,
+        "Errors": errors,
+    }
+
+
+def _EnvBool(name: str, default: bool) -> bool:
+    raw = os.getenv(name, "").strip().lower()
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _EnvTime(name: str, default: str) -> str:
+    normalized = _NormalizeTime(os.getenv(name, "").strip() or None)
+    return normalized or default
+
+
+def YesterdayReminderTimeForDate(run_date: date) -> str:
+    """Return the local send time for the day the reminder fires."""
+    if run_date.weekday() >= 5:
+        return _EnvTime("HEALTH_YESTERDAY_REMINDER_WEEKEND_TIME", DefaultYesterdayWeekendTime)
+    return _EnvTime("HEALTH_YESTERDAY_REMINDER_WEEKDAY_TIME", DefaultYesterdayWeekdayTime)
+
+
+def _MissingMainMeals(db: Session, user_id: int, log_date: date) -> list[str]:
+    log = _GetDailyLog(db, user_id, log_date)
+    if not log:
+        return list(MainMealTypes)
+    logged = {
+        row[0]
+        for row in db.query(MealEntry.MealType)
+        .filter(MealEntry.DailyLogId == log.DailyLogId)
+        .distinct()
+        .all()
+    }
+    return [meal_type for meal_type in MainMealTypes if meal_type not in logged]
+
+
+def _FormatMissingMealList(missing: list[str]) -> str:
+    labels = [_FormatMealLabel(meal_type) for meal_type in missing]
+    if len(labels) == 1:
+        return labels[0]
+    return f"{', '.join(labels[:-1])} and {labels[-1]}"
+
+
+def FormatYesterdayReminderMessage(log_date: date, missing: list[str]) -> str:
+    """Build the Discord message body for an incomplete previous day."""
+    day_text = f"{log_date.strftime('%A')} {log_date.day} {log_date.strftime('%B')}"
+    base_url = (
+        os.getenv("HEALTH_DASHBOARD_BASE_URL", "").strip() or DefaultHealthDashboardBaseUrl
+    ).rstrip("/")
+    return (
+        f"**Yesterday's log is incomplete** ({day_text})\n"
+        f"Not logged: {_FormatMissingMealList(missing)}\n"
+        f"{base_url}/log?date={log_date.isoformat()}"
+    )
+
+
+def RunYesterdayLogReminders(
+    db: Session,
+    run_date: date | None = None,
+    run_time: str | None = None,
+) -> dict:
+    """Send each parent a Discord reminder when their previous day is missing main meals.
+
+    Fires once per user per day, at 07:00 local on weekdays and 09:00 local at weekends.
+    Only Breakfast, Lunch, and Dinner are considered; snacks are ignored.
+    """
+    if not _EnvBool("HEALTH_YESTERDAY_REMINDER_ENABLED", True):
+        return {
+            "EligibleUsers": 0,
+            "ProcessedUsers": 0,
+            "NotificationsSent": 0,
+            "Skipped": 0,
+            "Errors": 0,
+        }
+
+    now = NowUtc()
+    parent_users = db.query(User).filter(User.Role == "Parent").all()
+    parent_ids = [user.Id for user in parent_users]
+    settings_rows = (
+        db.query(TaskSettings).filter(TaskSettings.UserId.in_(parent_ids)).all()
+        if parent_ids
+        else []
+    )
+    timezone_by_user_id = {
+        row.UserId: row.OverdueReminderTimeZone
+        for row in settings_rows
+        if row.OverdueReminderTimeZone
+    }
+
+    eligible_users = 0
+    processed_users = 0
+    notifications_sent = 0
+    skipped = 0
+    errors = 0
+
+    for user in parent_users:
+        settings = EnsureSettingsForUser(db, user.Id)
+        effective_zone = _ResolveRunZone(
+            timezone_by_user_id.get(user.Id) or settings.ReminderTimeZone
+        )
+        effective_date, effective_time = _ResolveEffectiveRunDateTime(
+            now_utc=now,
+            run_date=run_date,
+            run_time=run_time,
+            run_zone=effective_zone,
+        )
+        if not _TimeMatches(effective_time, YesterdayReminderTimeForDate(effective_date)):
+            continue
+
+        eligible_users += 1
+        processed_users += 1
+        log_date = effective_date - timedelta(days=1)
+
+        if _AlreadyRan(db, user.Id, effective_date, effective_time, YesterdayReminderType, ""):
+            skipped += 1
+            continue
+
+        try:
+            webhook_url = ResolveWebhookUrl(user.Id, user.Username)
+            if not webhook_url:
+                logger.warning(
+                    "No Discord webhook configured for user %s, skipping yesterday reminder",
+                    user.Id,
+                )
+                _RecordRun(
+                    db,
+                    user.Id,
+                    effective_date,
+                    effective_time,
+                    YesterdayReminderType,
+                    "",
+                    result="unconfigured",
+                    notification_sent=False,
+                    error_message="No Discord webhook configured for this user.",
+                )
+                skipped += 1
+                continue
+
+            missing = _MissingMainMeals(db, user.Id, log_date)
+            if not missing:
+                _RecordRun(
+                    db,
+                    user.Id,
+                    effective_date,
+                    effective_time,
+                    YesterdayReminderType,
+                    "",
+                    result="skipped",
+                    notification_sent=False,
+                )
+                skipped += 1
+                continue
+
+            SendDiscordMessage(webhook_url, FormatYesterdayReminderMessage(log_date, missing))
+            _RecordRun(
+                db,
+                user.Id,
+                effective_date,
+                effective_time,
+                YesterdayReminderType,
+                "",
+                result="sent",
+                notification_sent=True,
+            )
+            notifications_sent += 1
+
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Yesterday log reminder failed for user %s", user.Id)
+            errors += 1
+            # Record under "Error" rather than the reminder type, so a transient
+            # Discord failure does not consume this user's slot for the day and
+            # a later scheduler tick can still deliver the reminder. Retrying
+            # within the same minute would collide on the run's unique key, so
+            # only the first failure of that minute is recorded.
+            if not _AlreadyRan(db, user.Id, effective_date, effective_time, "Error", ""):
+                _RecordRun(
+                    db,
+                    user.Id,
+                    effective_date,
+                    effective_time,
+                    reminder_type="Error",
+                    meal_type="",
+                    result="error",
+                    notification_sent=False,
+                    error_message=str(exc),
+                )
 
     return {
         "EligibleUsers": eligible_users,

--- a/backend/tests/test_health_reminders_service.py
+++ b/backend/tests/test_health_reminders_service.py
@@ -1,7 +1,13 @@
 import json
 from datetime import date, datetime, timezone
 
+import pytest
+
+from app.modules.health.services.discord_service import ResolveWebhookUrl
 from app.modules.health.services.reminders_service import (
+    FormatYesterdayReminderMessage,
+    YesterdayReminderTimeForDate,
+    _FormatMissingMealList,
     _IsValidTime,
     _ParseFoodReminderSlots,
     _ParseFoodReminderTimes,
@@ -65,3 +71,64 @@ def test_resolve_effective_run_date_time_uses_adelaide_for_scheduler_defaults():
 
     assert effective_date == date(2026, 3, 9)
     assert effective_time == "02:30"
+
+
+@pytest.mark.parametrize(
+    ("run_date", "expected"),
+    [
+        (date(2026, 7, 27), "07:00"),  # Monday
+        (date(2026, 7, 31), "07:00"),  # Friday
+        (date(2026, 8, 1), "09:00"),  # Saturday
+        (date(2026, 8, 2), "09:00"),  # Sunday
+    ],
+)
+def test_yesterday_reminder_time_splits_weekdays_and_weekends(run_date, expected):
+    assert YesterdayReminderTimeForDate(run_date) == expected
+
+
+def test_yesterday_reminder_time_honors_env_overrides(monkeypatch):
+    monkeypatch.setenv("HEALTH_YESTERDAY_REMINDER_WEEKDAY_TIME", "06:30")
+    monkeypatch.setenv("HEALTH_YESTERDAY_REMINDER_WEEKEND_TIME", "bad-time")
+
+    assert YesterdayReminderTimeForDate(date(2026, 7, 31)) == "06:30"
+    assert YesterdayReminderTimeForDate(date(2026, 8, 1)) == "09:00"
+
+
+def test_format_missing_meal_list_uses_readable_labels():
+    assert _FormatMissingMealList(["Dinner"]) == "Dinner"
+    assert _FormatMissingMealList(["Breakfast", "Dinner"]) == "Breakfast and Dinner"
+    assert (
+        _FormatMissingMealList(["Breakfast", "Lunch", "Dinner"])
+        == "Breakfast, Lunch and Dinner"
+    )
+
+
+def test_format_yesterday_reminder_message_includes_day_meals_and_link(monkeypatch):
+    monkeypatch.setenv("HEALTH_DASHBOARD_BASE_URL", "https://health.example.test/")
+
+    message = FormatYesterdayReminderMessage(date(2026, 7, 31), ["Breakfast", "Dinner"])
+
+    assert "Friday 31 July" in message
+    assert "Not logged: Breakfast and Dinner" in message
+    assert "https://health.example.test/log?date=2026-07-31" in message
+
+
+def test_resolve_webhook_url_prefers_username_key(monkeypatch):
+    monkeypatch.setenv("DISCORD_KEVIN", " https://discord.test/kevin ")
+    monkeypatch.setenv("HEALTH_DISCORD_WEBHOOK_USER_1", "https://discord.test/by-id")
+
+    assert ResolveWebhookUrl(1, "kevin") == "https://discord.test/kevin"
+
+
+def test_resolve_webhook_url_falls_back_to_user_id_key(monkeypatch):
+    monkeypatch.delenv("DISCORD_BIANCA", raising=False)
+    monkeypatch.setenv("HEALTH_DISCORD_WEBHOOK_USER_2", "https://discord.test/by-id")
+
+    assert ResolveWebhookUrl(2, "bianca") == "https://discord.test/by-id"
+
+
+def test_resolve_webhook_url_is_optional(monkeypatch):
+    monkeypatch.delenv("DISCORD_NOBODY", raising=False)
+    monkeypatch.delenv("HEALTH_DISCORD_WEBHOOK_USER_9", raising=False)
+
+    assert ResolveWebhookUrl(9, "nobody") is None


### PR DESCRIPTION
Sends each parent a Discord message in their own channel when the previous day is missing a main meal.

## Behaviour

- Fires at **07:00 local on weekdays**, **09:00 at weekends**, once per person per day.
- Considers **Breakfast, Lunch, and Dinner** only. Snacks are ignored.
- Message names the missing meals and links to that day on the health dashboard.

## Design

- Extends the existing health reminders scheduler rather than adding a new one.
- Reuses `reminder_runs` for dedupe with a new `YesterdayIncomplete` type, so **no migration is needed**.
- Runs via `asyncio.to_thread` since it makes outbound HTTP calls, keeping the event loop free.
- Webhooks resolve from `DISCORD_<USERNAME>`, falling back to `HEALTH_DISCORD_WEBHOOK_USER_<id>`. With no webhook configured the run is recorded as `unconfigured` and nothing is sent.
- Delivery failures are recorded under the `Error` type rather than the reminder type, so a transient Discord outage does not consume the day's slot and a later tick can still deliver. This was raised by independent review and fixed before merge.
- Adds an admin-only `POST /api/health/settings/reminders/run-yesterday-check` for manual runs.

## Verification

- 102 backend tests pass (one pre-existing `datetime.utcnow()` deprecation warning).
- Dry run against production data confirmed correct per-user missing meals, once-per-day dedupe, no fire at the wrong time, and the weekend slot.
- Failure path exercised end to end: fail, retry, recover and deliver, then correctly skip.
- Discord webhook contract verified live: 204 success, 400 on empty content, 401 on bad token.
- One real message delivered to a live channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)