### PR TITLE
Fix Health symptom record linkage

### DIFF
--- a/backend/app/modules/health/schemas.py
+++ b/backend/app/modules/health/schemas.py
@@ -16,6 +16,7 @@ class MealType(str, Enum):
 
 
 MealTypeValue = MealType
+UUID_PATTERN = r"^[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
 
 
 class ImageScanMode(str, Enum):
@@ -961,7 +962,7 @@ class HeadacheEvent(BaseModel):
 
 
 class UpsertHeadacheEventInput(BaseModel):
-    HeadacheEventId: str | None = None
+    HeadacheEventId: str | None = Field(default=None, pattern=UUID_PATTERN)
     LogDate: str
     OnsetAt: datetime | None = None
     EventType: str = Field(default="headache", max_length=30)
@@ -981,9 +982,9 @@ class MedicationDose(BaseModel):
 
 
 class UpsertMedicationDoseInput(BaseModel):
-    MedicationDoseId: str | None = None
+    MedicationDoseId: str | None = Field(default=None, pattern=UUID_PATTERN)
     LogDate: str
-    HeadacheEventId: str | None = None
+    HeadacheEventId: str | None = Field(default=None, pattern=UUID_PATTERN)
     TakenAt: datetime | None = None
     MedicationName: str = Field(min_length=1, max_length=200)
     Dose: str | None = Field(default=None, max_length=120)

--- a/backend/app/modules/health/services/symptoms_service.py
+++ b/backend/app/modules/health/services/symptoms_service.py
@@ -1,32 +1,137 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+
 from app.modules.health.models import HeadacheEvent, MedicationDose
-from app.modules.health.schemas import HeadacheEvent as HeadacheSchema, MedicationDose as DoseSchema, UpsertHeadacheEventInput, UpsertMedicationDoseInput
+from app.modules.health.schemas import (
+    HeadacheEvent as HeadacheSchema,
+    MedicationDose as DoseSchema,
+    UpsertHeadacheEventInput,
+    UpsertMedicationDoseInput,
+)
 from app.modules.health.utils.dates import ParseIsoDate
 
+
+def _RecoverIdempotentInsert(
+    db: Session,
+    model: Any,
+    id_column: Any,
+    record_id: str,
+    user_id: int,
+    response_schema: Any,
+    field_name: str,
+):
+    existing = db.query(model).filter(id_column == record_id, model.UserId == user_id).first()
+    if existing is not None:
+        return response_schema.model_validate(existing, from_attributes=True)
+    collision = db.query(model).filter(id_column == record_id).first()
+    if collision is not None:
+        raise ValueError(f"{field_name} is already in use.")
+    return None
+
+
 def UpsertHeadache(db: Session, user_id: int, payload: UpsertHeadacheEventInput) -> HeadacheSchema:
-    row = db.query(HeadacheEvent).filter(HeadacheEvent.HeadacheEventId == payload.HeadacheEventId, HeadacheEvent.UserId == user_id).first() if payload.HeadacheEventId else None
-    if row is None:
-        row = HeadacheEvent(HeadacheEventId=str(uuid.uuid4()), UserId=user_id, LogDate=ParseIsoDate(payload.LogDate))
+    row = (
+        db.query(HeadacheEvent)
+        .filter(HeadacheEvent.HeadacheEventId == payload.HeadacheEventId, HeadacheEvent.UserId == user_id)
+        .first()
+        if payload.HeadacheEventId
+        else None
+    )
+    created = row is None
+    if created:
+        row = HeadacheEvent(
+            HeadacheEventId=payload.HeadacheEventId or str(uuid.uuid4()),
+            UserId=user_id,
+            LogDate=ParseIsoDate(payload.LogDate),
+        )
         db.add(row)
-    for key, value in payload.model_dump(exclude={"HeadacheEventId", "LogDate"}).items(): setattr(row, key, value)
-    row.LogDate = ParseIsoDate(payload.LogDate); row.UpdatedAt = datetime.utcnow(); db.commit(); db.refresh(row)
+    for key, value in payload.model_dump(exclude={"HeadacheEventId", "LogDate"}).items():
+        setattr(row, key, value)
+    row.LogDate = ParseIsoDate(payload.LogDate)
+    row.UpdatedAt = datetime.now(timezone.utc)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        if not created or not payload.HeadacheEventId:
+            raise
+        recovered = _RecoverIdempotentInsert(
+            db,
+            HeadacheEvent,
+            HeadacheEvent.HeadacheEventId,
+            payload.HeadacheEventId,
+            user_id,
+            HeadacheSchema,
+            "HeadacheEventId",
+        )
+        if recovered is not None:
+            return recovered
+        raise
+    db.refresh(row)
     return HeadacheSchema.model_validate(row, from_attributes=True)
+
 
 def GetHeadaches(db: Session, user_id: int, log_date: str | None = None):
     query = db.query(HeadacheEvent).filter(HeadacheEvent.UserId == user_id)
-    if log_date: query = query.filter(HeadacheEvent.LogDate == ParseIsoDate(log_date))
-    return [HeadacheSchema.model_validate(x, from_attributes=True) for x in query.order_by(HeadacheEvent.OnsetAt.desc()).all()]
+    if log_date:
+        query = query.filter(HeadacheEvent.LogDate == ParseIsoDate(log_date))
+    return [
+        HeadacheSchema.model_validate(x, from_attributes=True)
+        for x in query.order_by(HeadacheEvent.OnsetAt.desc()).all()
+    ]
+
 
 def UpsertDose(db: Session, user_id: int, payload: UpsertMedicationDoseInput) -> DoseSchema:
-    row = db.query(MedicationDose).filter(MedicationDose.MedicationDoseId == payload.MedicationDoseId, MedicationDose.UserId == user_id).first() if payload.MedicationDoseId else None
-    if row is None: row = MedicationDose(MedicationDoseId=str(uuid.uuid4()), UserId=user_id, LogDate=ParseIsoDate(payload.LogDate)); db.add(row)
-    for key, value in payload.model_dump(exclude={"MedicationDoseId", "LogDate"}).items(): setattr(row, key, value)
-    row.LogDate = ParseIsoDate(payload.LogDate); row.UpdatedAt = datetime.utcnow(); db.commit(); db.refresh(row)
+    row = (
+        db.query(MedicationDose)
+        .filter(MedicationDose.MedicationDoseId == payload.MedicationDoseId, MedicationDose.UserId == user_id)
+        .first()
+        if payload.MedicationDoseId
+        else None
+    )
+    created = row is None
+    if created:
+        row = MedicationDose(
+            MedicationDoseId=payload.MedicationDoseId or str(uuid.uuid4()),
+            UserId=user_id,
+            LogDate=ParseIsoDate(payload.LogDate),
+        )
+        db.add(row)
+    for key, value in payload.model_dump(exclude={"MedicationDoseId", "LogDate"}).items():
+        setattr(row, key, value)
+    row.LogDate = ParseIsoDate(payload.LogDate)
+    row.UpdatedAt = datetime.now(timezone.utc)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        if not created or not payload.MedicationDoseId:
+            raise
+        recovered = _RecoverIdempotentInsert(
+            db,
+            MedicationDose,
+            MedicationDose.MedicationDoseId,
+            payload.MedicationDoseId,
+            user_id,
+            DoseSchema,
+            "MedicationDoseId",
+        )
+        if recovered is not None:
+            return recovered
+        raise
+    db.refresh(row)
     return DoseSchema.model_validate(row, from_attributes=True)
+
 
 def GetDoses(db: Session, user_id: int, log_date: str | None = None):
     query = db.query(MedicationDose).filter(MedicationDose.UserId == user_id)
-    if log_date: query = query.filter(MedicationDose.LogDate == ParseIsoDate(log_date))
-    return [DoseSchema.model_validate(x, from_attributes=True) for x in query.order_by(MedicationDose.TakenAt.desc()).all()]
+    if log_date:
+        query = query.filter(MedicationDose.LogDate == ParseIsoDate(log_date))
+    return [
+        DoseSchema.model_validate(x, from_attributes=True)
+        for x in query.order_by(MedicationDose.TakenAt.desc()).all()
+    ]

--- a/backend/app/modules/integrations/health_mcp/router.py
+++ b/backend/app/modules/integrations/health_mcp/router.py
@@ -809,7 +809,10 @@ def GetMeasurementsRoute(
 
 @router.post("/headaches", response_model=HeadacheEvent)
 def UpsertHeadacheRoute(payload: UpsertHeadacheEventInput, db: Session = Depends(GetDb), user: UserContext = Depends(RequireModuleRole("health", write=True))) -> HeadacheEvent:
-    return UpsertHeadache(db, user.Id, payload)
+    try:
+        return UpsertHeadache(db, user.Id, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
 @router.get("/headaches", response_model=list[HeadacheEvent])
@@ -819,7 +822,10 @@ def GetHeadachesRoute(log_date: str | None = None, db: Session = Depends(GetDb),
 
 @router.post("/medication-doses", response_model=MedicationDose)
 def UpsertMedicationDoseRoute(payload: UpsertMedicationDoseInput, db: Session = Depends(GetDb), user: UserContext = Depends(RequireModuleRole("health", write=True))) -> MedicationDose:
-    return UpsertDose(db, user.Id, payload)
+    try:
+        return UpsertDose(db, user.Id, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
 @router.get("/medication-doses", response_model=list[MedicationDose])

--- a/backend/tests/test_health_symptoms_service.py
+++ b/backend/tests/test_health_symptoms_service.py
@@ -1,0 +1,189 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
+
+from app.modules.health.models import HeadacheEvent, MedicationDose
+from app.modules.health.schemas import UpsertHeadacheEventInput, UpsertMedicationDoseInput
+from app.modules.health.services.symptoms_service import UpsertDose, UpsertHeadache
+from app.modules.integrations.health_mcp import router as health_mcp_router
+
+
+class _Query:
+    def __init__(self, db):
+        self.db = db
+
+    def filter(self, *_conditions):
+        return self
+
+    def first(self):
+        return self.db.query_rows.pop(0) if self.db.query_rows else None
+
+
+class _Db:
+    def __init__(self, query_rows=None, commit_error=None):
+        self.query_rows = list(query_rows or [])
+        self.commit_error = commit_error
+        self.added = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    def query(self, _model):
+        return _Query(self)
+
+    def add(self, row):
+        self.added.append(row)
+
+    def commit(self):
+        self.commits += 1
+        if self.commit_error is not None:
+            error = self.commit_error
+            self.commit_error = None
+            raise error
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def refresh(self, _row):
+        return None
+
+
+def test_headache_create_preserves_caller_supplied_id():
+    db = _Db()
+
+    result = UpsertHeadache(
+        db,
+        7,
+        UpsertHeadacheEventInput(
+            HeadacheEventId="11111111-1111-4111-8111-111111111111",
+            LogDate="2026-08-10",
+            Severity=2,
+        ),
+    )
+
+    assert result.HeadacheEventId == "11111111-1111-4111-8111-111111111111"
+    assert db.added[0].HeadacheEventId == result.HeadacheEventId
+    assert db.commits == 1
+
+
+def test_medication_create_preserves_caller_supplied_id_and_headache_link():
+    db = _Db()
+
+    result = UpsertDose(
+        db,
+        7,
+        UpsertMedicationDoseInput(
+            MedicationDoseId="22222222-2222-4222-8222-222222222222",
+            HeadacheEventId="11111111-1111-4111-8111-111111111111",
+            LogDate="2026-08-10",
+            MedicationName="Panadol",
+            Dose="2 tablets",
+        ),
+    )
+
+    assert result.MedicationDoseId == "22222222-2222-4222-8222-222222222222"
+    assert result.HeadacheEventId == "11111111-1111-4111-8111-111111111111"
+    assert db.added[0].MedicationDoseId == result.MedicationDoseId
+    assert db.commits == 1
+
+
+def test_concurrent_headache_retry_returns_the_winning_record():
+    winning = HeadacheEvent(
+        HeadacheEventId="11111111-1111-4111-8111-111111111111",
+        UserId=7,
+        LogDate="2026-08-10",
+        EventType="headache",
+        Severity=2,
+    )
+    db = _Db(
+        query_rows=[None, winning],
+        commit_error=IntegrityError("INSERT", {}, Exception("duplicate key")),
+    )
+
+    result = UpsertHeadache(
+        db,
+        7,
+        UpsertHeadacheEventInput(
+            HeadacheEventId=winning.HeadacheEventId,
+            LogDate="2026-08-10",
+            Severity=2,
+        ),
+    )
+
+    assert result.HeadacheEventId == winning.HeadacheEventId
+    assert db.rollbacks == 1
+
+
+def test_concurrent_medication_retry_returns_the_winning_record():
+    winning = MedicationDose(
+        MedicationDoseId="22222222-2222-4222-8222-222222222222",
+        HeadacheEventId="11111111-1111-4111-8111-111111111111",
+        UserId=7,
+        LogDate="2026-08-10",
+        MedicationName="Panadol",
+        Dose="2 tablets",
+    )
+    db = _Db(
+        query_rows=[None, winning],
+        commit_error=IntegrityError("INSERT", {}, Exception("duplicate key")),
+    )
+
+    result = UpsertDose(
+        db,
+        7,
+        UpsertMedicationDoseInput(
+            MedicationDoseId=winning.MedicationDoseId,
+            HeadacheEventId=winning.HeadacheEventId,
+            LogDate="2026-08-10",
+            MedicationName="Panadol",
+            Dose="2 tablets",
+        ),
+    )
+
+    assert result.MedicationDoseId == winning.MedicationDoseId
+    assert db.rollbacks == 1
+
+
+@pytest.mark.parametrize(
+    ("schema", "field"),
+    [
+        (UpsertHeadacheEventInput, "HeadacheEventId"),
+        (UpsertMedicationDoseInput, "MedicationDoseId"),
+        (UpsertMedicationDoseInput, "HeadacheEventId"),
+    ],
+)
+def test_symptom_record_ids_require_canonical_uuid_shape(schema, field):
+    values = {"LogDate": "2026-08-10", "MedicationName": "Panadol", field: "not-a-uuid"}
+
+    with pytest.raises(ValidationError):
+        schema(**values)
+
+
+@pytest.mark.parametrize(
+    ("route", "service_name", "payload"),
+    [
+        (
+            health_mcp_router.UpsertHeadacheRoute,
+            "UpsertHeadache",
+            UpsertHeadacheEventInput(LogDate="2026-08-10"),
+        ),
+        (
+            health_mcp_router.UpsertMedicationDoseRoute,
+            "UpsertDose",
+            UpsertMedicationDoseInput(LogDate="2026-08-10", MedicationName="Panadol"),
+        ),
+    ],
+)
+def test_symptom_routes_translate_id_collisions_to_bad_request(monkeypatch, route, service_name, payload):
+    def raise_collision(*_args, **_kwargs):
+        raise ValueError("record id is already in use")
+
+    monkeypatch.setattr(health_mcp_router, service_name, raise_collision)
+
+    with pytest.raises(HTTPException) as exc_info:
+        route(payload, db=object(), user=SimpleNamespace(Id=7))
+
+    assert exc_info.value.status_code == 400
+    assert "already in use" in exc_info.value.detail


### PR DESCRIPTION
## Summary
- preserve MCP-supplied headache and medication record IDs on create
- recover idempotently from concurrent retries and reject UUID collisions cleanly
- validate symptom record IDs and translate collision errors to HTTP 400

## Verification
- `./scripts/dev.sh --build-only`
- `./scripts/dev.sh --test-only` (111 passed; one pre-existing warning)